### PR TITLE
fix: images output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build Next.js
         run: yarn build
       - name: Copy CNAME file
-        run: cp public/CNAME out/
+        run: cp public/ out/
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Images do not seem to be loading on the site, probably because they are not being copied to the "out" folder.