### PR TITLE
feat: run unit tests only on main branch

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,5 +1,7 @@
 name: Jest unit test
-on: push
+on:
+  push:
+      branches: [ "main" ]
 
 jobs:
   test:


### PR DESCRIPTION
## Reasoning:
Because we are on a free account on Github, we will be saving some Actions minutes by running unit tests only when something is merged into main. Only 1 developer/tester in this repo, it's possible to run the unit tests locally on the computer before the commit, so we don't have to run them on Github Actions at every commit.